### PR TITLE
Twemcache starts spinning with 100% CPU because of bad UDP packages

### DIFF
--- a/src/mc_connection.c
+++ b/src/mc_connection.c
@@ -312,6 +312,10 @@ conn_cleanup(struct conn *c)
     if (c->write_and_free != NULL) {
         mc_free(c->write_and_free);
     }
+
+    if (c->udp) {
+        conn_set_state(c, CONN_READ);
+    }
 }
 
 void

--- a/src/mc_core.c
+++ b/src/mc_core.c
@@ -147,7 +147,7 @@ core_read_udp(struct conn *c)
         res -= 8;
         memmove(c->rbuf, c->rbuf + 8, res);
 
-        c->rbytes += res;
+        c->rbytes = res;
         c->rcurr = c->rbuf;
 
         return READ_DATA_RECEIVED;


### PR DESCRIPTION
Patch from Upstream Memcached - https://github.com/memcached/memcached/commit/954f6dddc41c80d2e625bce63744df5556a425bb

"Don't permanently close UDP listeners on error
Also, don't inflate rbytes as we can only ever process one UDP packet at a
time.

Patch by pi3orama. Fixed by Dormando to use the correct state and actually
work."
